### PR TITLE
Improve query efficiency

### DIFF
--- a/Pdf/PdfController.cs
+++ b/Pdf/PdfController.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Text;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json.Linq;
 using Pdf.Storage.Data;
 using Pdf.Storage.Hangfire;
@@ -158,6 +158,7 @@ namespace Pdf.Storage.Pdf
         {
             var processedFileFound = _context
                 .PdfFiles
+                .AsNoTracking()
                 .Any(x =>
                     x.GroupId == groupId &&
                     x.FileId == pdfId &&

--- a/Pdf/PdfController.cs
+++ b/Pdf/PdfController.cs
@@ -108,7 +108,7 @@ namespace Pdf.Storage.Pdf
                 return BadRequest("Only extensions 'pdf' and 'html' are supported.");
             }
 
-            var pdfEntity = _context.PdfFiles.SingleOrDefault(x => x.GroupId == groupId && x.FileId == pdfId);
+            var pdfEntity = _context.PdfFiles.FirstOrDefault(x => x.GroupId == groupId && x.FileId == pdfId);
 
             if (pdfEntity == null)
             {
@@ -204,7 +204,7 @@ namespace Pdf.Storage.Pdf
 
         private bool RemovePdf(string groupId, string pdfId)
         {
-            var pdfEntity = _context.PdfFiles.SingleOrDefault(x => x.GroupId == groupId && x.FileId == pdfId);
+            var pdfEntity = _context.PdfFiles.FirstOrDefault(x => x.GroupId == groupId && x.FileId == pdfId);
 
             if (pdfEntity == null)
                 return false;

--- a/Pdf/PdfUsageCountController.cs
+++ b/Pdf/PdfUsageCountController.cs
@@ -20,6 +20,7 @@ namespace Pdf.Storage.Pdf
         public IActionResult GetSimpleCount([Required] string groupId)
         {
             var group = _context.PdfFiles
+                .AsNoTracking()
                 .Include(x => x.Usage)
                 .Where(x => x.GroupId == groupId && x.Processed);
 
@@ -34,6 +35,7 @@ namespace Pdf.Storage.Pdf
         public IActionResult GetSimpleCount([Required] string groupId, [Required] string pdfId)
         {
             var result = _context.PdfFiles
+                .AsNoTracking()
                 .Include(x => x.Usage)
                 .Single(x => x.GroupId == groupId && x.FileId == pdfId);
 


### PR DESCRIPTION
Generating pdfs have issues with too many queries left open on low tier sql db, maybe due to not enough pools.
Attempting to make queries more efficient.