### PR TITLE
Hangfire worker count configuration

### DIFF
--- a/Startup.cs
+++ b/Startup.cs
@@ -163,10 +163,19 @@ namespace Pdf.Storage
 
             });
 
+            var workerCount = 4;
+            if (!string.IsNullOrEmpty(Configuration["Hangfire:WorkerCount"]))
+            {
+                if (!int.TryParse(Configuration["Hangfire:WorkerCount"], out workerCount))
+                {
+                    throw new InvalidOperationException("Invalid WorkerCount on cofiguration.");
+                }
+            }
+
             var options = new BackgroundJobServerOptions
             {
                 Queues = HangfireConstants.GetQueues().ToArray(),
-                WorkerCount = 4,
+                WorkerCount = workerCount,
             };
 
             app.Map("/hangfire", appBuilder =>

--- a/appsettings.json
+++ b/appsettings.json
@@ -34,7 +34,8 @@
   "Hangfire": {
     "AllowedIpAddresses": [],
     "DashboardUser": "",
-    "DashboardPassword": ""
+    "DashboardPassword": "",
+    "WorkerCount": 4
   },
   "ApplicationInsights": {
     "InstrumentationKey": ""

--- a/appsettings.json
+++ b/appsettings.json
@@ -35,6 +35,8 @@
     "AllowedIpAddresses": [],
     "DashboardUser": "",
     "DashboardPassword": "",
+    // If database connections get timeouted due to no pools available.
+    // It may be because of too many workers use many connections, you can reduce the amount of workers here.
     "WorkerCount": 4
   },
   "ApplicationInsights": {


### PR DESCRIPTION
Added configuration for hangfire worker count, to be able to reduce the amount of workers.

If database connections get timeouted due to no pools available.
It may be because of too many workers use many connections.