### PR TITLE
Setting a custom PaperFormat with Width/Height options

### DIFF
--- a/ApiDescription.md
+++ b/ApiDescription.md
@@ -99,9 +99,12 @@ Pdf can contain following options
   "marginTop": "120px",
   "marginBottom": "120px",
   "marginLeft": "20px",
-  "marginRight": "20px"
+  "marginRight": "20px",
+  "width": null,
+  "height": null
 }
 ```
+Values in width AND height (in inches) creates a custom sized paper. If omitted the default A4 paper size will be used.
 
 For further information, see [https://www.puppeteersharp.com/api/PuppeteerSharp.PdfOptions.html](https://www.puppeteersharp.com/api/PuppeteerSharp.PdfOptions.html).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # ! IMPORTANT: Keep chromium version synced with version from package 'PuppeteerSharp'
 # and match it with from https://pkgs.alpinelinux.org/packages
-ARG chromium_version=89.0.4389.128-r2
+ARG chromium_version=91.0.4472.101-r0
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100-alpine3.10 as dotnetBuild
 ARG chromium_version

--- a/Pdf.Storage.csproj
+++ b/Pdf.Storage.csproj
@@ -55,7 +55,7 @@
     <!--  When you update PuppeteerSharp you must also find corresponding version
           in alpine at Dockerfile. Alpine limits available chromium versions available so don't update
           this without check them out. Chromium version must be about same as puppeteer expects -->
-    <PackageReference Include="PuppeteerSharp" Version="2.0.3" />
+    <PackageReference Include="PuppeteerSharp" Version="4.0.0" />
 
     <!-- Remove this once testing library is updated -->
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0" />

--- a/Pdf/PdfQueue.cs
+++ b/Pdf/PdfQueue.cs
@@ -80,7 +80,12 @@ namespace Pdf.Storage.Pdf
 
                 var defaultPdfOptions = new PdfOptions
                 {
-                    Format = PaperFormat.A4
+                    Format = options.ContainsKey("Width") && options.ContainsKey("Height") ?
+                                    new PaperFormat(
+                                    	options["Width"].Value<decimal>(),
+                                    	options["Height"].Value<decimal>()
+                                    ) :
+                                    PaperFormat.A4
                 };
 
                 return await page.PdfDataAsync(new PdfOptions


### PR DESCRIPTION
Needed to have a setter for custom paper size, for example a receipt (width 80mm)