### PR TITLE
Feat: Allow PathBase to be configured

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # ! IMPORTANT: Keep chromium version synced with version from package 'PuppeteerSharp'
 # and match it with from https://pkgs.alpinelinux.org/packages
-ARG chromium_version=93.0.4577.82-r1
+ARG chromium_version=93.0.4577.82-r2
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100-alpine3.10 as dotnetBuild
 ARG chromium_version

--- a/Readme.md
+++ b/Readme.md
@@ -188,6 +188,13 @@ Use local disk as storage.
 }
 ```
 
+## BaseUrl and PathBase configuration parameters
+
+BaseUrl parameter needs to be set to that domain+path where this is hosted. Eg. if it is hosted at https://pdf-storage.example.com then BaseUrl needs to be set as "https://pdf-storage.example.com"
+
+If you want to deploy this application to another than root path, eg. https://example.com/pdf-storage then PathBase needs to be set to "/pdf-storage" and BaseUrl "https://example.com/pdf-storage"
+
+
 ## Migrations
 
 Tooling requires `dotnet-ef` available, so run:

--- a/Startup.cs
+++ b/Startup.cs
@@ -154,6 +154,8 @@ namespace Pdf.Storage
 
         public void Configure(IApplicationBuilder app)
         {
+            app.UsePathBase(Configuration["PathBase"]);
+
             app.UseCors("CorsPolicy");
             app.UseRouting();
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -8,6 +8,7 @@
     }
   },
   "BaseUrl": "http://localhost:5000",
+  "PathBase":  "",
   "ConnectionString": "User ID=postgres;Password=passwordfortesting;Host=localhost;Port=5432;Database=pdfstorage;Pooling=true;",
   "ApiAuthentication": {
     "Keys": [ "apikeyfortesting" ]


### PR DESCRIPTION
PathBase setting is shown in the appsettings.json for example. It can be null or empty string and then it doesn't affect routing in any way, so this is backward compatible. If it is set, it must start with / eg. "/basepath". More info about the UsePathBase here https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.usepathbaseextensions.usepathbase?view=aspnetcore-6.0