### PR TITLE
Opti/pdf generation optimizations

### DIFF
--- a/Data/PdfEntity.cs
+++ b/Data/PdfEntity.cs
@@ -6,8 +6,6 @@ namespace Pdf.Storage.Data
 {
     public class PdfEntity
     {
-        public PdfEntity() {}
-
         public PdfEntity(string groupId, PdfType type)
         {
             GroupId = groupId;
@@ -24,9 +22,9 @@ namespace Pdf.Storage.Data
         public bool Removed { get; set; }
         public PdfType Type  { get; protected set; }
         public int OpenedTimes { get; set; }
-        public string HangfireJobId { get; set; }
+        public string HangfireJobId { get; set; } = string.Empty;
         public ICollection<PdfOpenedEntity> Usage { get; protected set; } = new List<PdfOpenedEntity>();
-        public JObject Options { get; set; }
+        public JObject Options { get; set; } = JObject.Parse("{}");
 
         public bool IsValidForHighPriority() => !Processed && Type == PdfType.Pdf && HangfireJobId != null;
         public void MarkAsHighPriority(string newHangfireJobId)

--- a/Pdf.Storage.csproj
+++ b/Pdf.Storage.csproj
@@ -8,6 +8,7 @@
     <GenerateProgramFile>false</GenerateProgramFile>
     <UserSecretsId>29daae28-ca01-4571-a752-561bae77dd89</UserSecretsId>
     <LangVersion>10.0</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/Pdf/PdfController.cs
+++ b/Pdf/PdfController.cs
@@ -75,8 +75,7 @@ namespace Pdf.Storage.Pdf
 
                 _context.SaveChanges();
 
-                var template = GetParsedHtmlTemplateOfPdfDocument(entity.Id, request.Html, templatedRow);
-
+                var template = GetParsedHtmlTemplateOfPdfDocument(request.Html, templatedRow);
                 _templateCache.Store(entity.Id, template);
 
                 // There is a small chance of data loss if the program shuts down/crashes before the job is ran to persist the template
@@ -94,7 +93,7 @@ namespace Pdf.Storage.Pdf
             return Accepted(responses.ToList());
         }
 
-        private string GetParsedHtmlTemplateOfPdfDocument(Guid pdfEntityId, string html, JObject templateData)
+        private string GetParsedHtmlTemplateOfPdfDocument(string html, JObject templateData)
         {
             var templatedHtml = _templatingEngine.Render(html, templateData);
             templatedHtml = TemplateUtils.AddWaitForAllPageElementsFixToHtml(templatedHtml);

--- a/Pdf/TemplateCacheService.cs
+++ b/Pdf/TemplateCacheService.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace Pdf.Storage.Pdf
+{
+    public class TemplateCacheService
+    {
+        private readonly ConcurrentDictionary<Guid, string> _cache;
+
+        public TemplateCacheService()
+        {
+            _cache = new ConcurrentDictionary<Guid, string>();
+        }
+
+        public void Store(Guid pdfEntityId, string value)
+        {
+            _cache.TryAdd(pdfEntityId, value);
+        }
+
+        public string? Get(Guid pdfEntityId)
+        {
+            return _cache.TryGetValue(pdfEntityId, out var value) ? value : default;
+        }
+
+        public void Remove(Guid pdfEntityId)
+        {
+            _cache.TryRemove(pdfEntityId, out _);
+        }
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -69,6 +69,8 @@ namespace Pdf.Storage
 
             services.AddHostedService<ApplicationInsightsTelemetryBackgroundService>();
 
+            services.AddSingleton<TemplateCacheService>();
+
             switch (Configuration["DbType"])
             {
                 case "inMemory":

--- a/Test/Utils/TestStartup.cs
+++ b/Test/Utils/TestStartup.cs
@@ -48,6 +48,8 @@ namespace Pdf.Storage.Hangfire
                 return (HangfireMock)provider.GetService<IHangfireQueue>();
             });
 
+            services.AddSingleton<TemplateCacheService>();
+
             var dbId = Guid.NewGuid().ToString();
             services.AddDbContext<PdfDataContext>(opt => opt.UseInMemoryDatabase(dbId));
 


### PR DESCRIPTION
Speeds up the `AddNewPdf` endpoint by not waiting for the template to be persisted in the storage, which may sometimes take up to ~1 second when using Azure storage.