### PR TITLE
Added options 'landscape' and 'format'

### DIFF
--- a/ApiDescription.md
+++ b/ApiDescription.md
@@ -42,6 +42,7 @@ Pdf can contain following options
 
 ```json
 {
+  "format": "A4",
   "footerTemplate": "<div style=\"color: black; font-size: 12px; width: 100%; margin-left: 28px;\"><span class=\"pageNumber\"></span>/<span class=\"totalPages\"></span></div>",
   "headerTemplate": "<div style=\"color: black; font-size: 12px; width: 100%; margin-left: 28px;\">Some header</div>",
   "printBackground": true,
@@ -57,6 +58,6 @@ Pdf can contain following options
   "scale": null
 }
 ```
-Values in width AND height (in inches) creates a custom sized paper. If omitted the default A4 paper size will be used.
+Format takes priority over width and height values. Values in width AND height (in inches) creates a custom sized paper. If format and size params are omitted the default A4 paper size will be used.
 
 For further information, see [https://www.puppeteersharp.com/api/PuppeteerSharp.PdfOptions.html](https://www.puppeteersharp.com/api/PuppeteerSharp.PdfOptions.html).

--- a/ApiDescription.md
+++ b/ApiDescription.md
@@ -45,6 +45,7 @@ Pdf can contain following options
   "footerTemplate": "<div style=\"color: black; font-size: 12px; width: 100%; margin-left: 28px;\"><span class=\"pageNumber\"></span>/<span class=\"totalPages\"></span></div>",
   "headerTemplate": "<div style=\"color: black; font-size: 12px; width: 100%; margin-left: 28px;\">Some header</div>",
   "printBackground": true,
+  "landscape": false,
   "preferCSSPageSize": false,
   "pageRanges": null,
   "marginTop": "120px",

--- a/Pdf/PdfQueue.cs
+++ b/Pdf/PdfQueue.cs
@@ -99,7 +99,7 @@ namespace Pdf.Storage.Pdf
 
                 return await page.PdfDataAsync(new PdfOptions
                 {
-                    Format = defaultPdfOptions.Format,
+                    Format = options.ContainsKey("format") ? Format(options["format"].Value<string>()) : defaultPdfOptions.Format,
                     DisplayHeaderFooter = options.ContainsKey("footerTemplate") || options.ContainsKey("headerTemplate"),
                     FooterTemplate = options.ContainsKey("footerTemplate") ? options["footerTemplate"].Value<string>() : defaultPdfOptions.FooterTemplate,
                     HeaderTemplate = options.ContainsKey("headerTemplate") ? options["headerTemplate"].Value<string>() : defaultPdfOptions.HeaderTemplate,
@@ -130,5 +130,20 @@ namespace Pdf.Storage.Pdf
                 browser?.Dispose();
             }
         }
+
+        private static PaperFormat Format(string format) => format switch {
+            "Letter" => PaperFormat.Letter,
+            "Legal" => PaperFormat.Legal,
+            "Tabloid" => PaperFormat.Tabloid,
+            "Ledger" => PaperFormat.Ledger,
+            "A0" => PaperFormat.A0,
+            "A1" => PaperFormat.A1,
+            "A2" => PaperFormat.A2,
+            "A3" => PaperFormat.A3,
+            "A4" => PaperFormat.A4,
+            "A5" => PaperFormat.A5,
+            "A6" => PaperFormat.A6,
+            _ => PaperFormat.A4,
+        };
     }
 }

--- a/Pdf/PdfQueue.cs
+++ b/Pdf/PdfQueue.cs
@@ -104,6 +104,7 @@ namespace Pdf.Storage.Pdf
                     FooterTemplate = options.ContainsKey("footerTemplate") ? options["footerTemplate"].Value<string>() : defaultPdfOptions.FooterTemplate,
                     HeaderTemplate = options.ContainsKey("headerTemplate") ? options["headerTemplate"].Value<string>() : defaultPdfOptions.HeaderTemplate,
                     PrintBackground = options.ContainsKey("printBackground") ? options["printBackground"].Value<bool>() : defaultPdfOptions.PrintBackground,
+                    Landscape = options.ContainsKey("landscape") ? options["landscape"].Value<bool>() : defaultPdfOptions.Landscape,
                     PreferCSSPageSize = options.ContainsKey("preferCSSPageSize") ? options["preferCSSPageSize"].Value<bool>() : defaultPdfOptions.PreferCSSPageSize,
                     PageRanges = options.ContainsKey("pageRanges") ? options["pageRanges"].Value<string>() : defaultPdfOptions.PageRanges,
                     Scale = options.ContainsKey("scale") ? options["scale"].Value<decimal>() : defaultPdfOptions.Scale,


### PR DESCRIPTION
This PR adds the following PdfOptions:

**format:** paper format as string. https://www.puppeteersharp.com/api/PuppeteerSharp.PdfOptions.html#PuppeteerSharp_PdfOptions_Format
Format takes priority over width and height values. Defaults to A4 as before. These are default behaviors for PuppeteerSharp PdfOptions.

**landscape:** paper orientation.
https://www.puppeteersharp.com/api/PuppeteerSharp.PdfOptions.html#PuppeteerSharp_PdfOptions_Landscape
Defaults to false.
